### PR TITLE
New orderings (BFSOrdering & SubTreeComplexityOrdering) and some minor changes.

### DIFF
--- a/faulttree/faulttree.py
+++ b/faulttree/faulttree.py
@@ -84,6 +84,19 @@ class FaultTree:
             return self.basic_events[key]
         return None
 
+    def get_basic_event_key(self, basic_event):
+        """
+        Returns the key the given BasicEvent.
+        :param basic_event: The BasicEvent to get the key of.
+        :return: The key of the BasicEvent or None, if it could not be
+                 found.
+        """
+        reverse_map = {v: k for k, v in self.basic_events.items()}
+        if basic_event in reverse_map:
+            return reverse_map[basic_event]
+        else:
+            return None
+
     def _construct_gates(self):
         """
         Constructs the set of all Gates in the system and returns it.

--- a/faulttree/faulttree.py
+++ b/faulttree/faulttree.py
@@ -1,4 +1,5 @@
 import collections
+from faulttree.gates import BasicEvent
 
 
 class FaultTree:
@@ -127,6 +128,26 @@ class FaultTree:
         Returns the system of the Fault Tree.
         """
         return self.system
+
+    def max_depth(self):
+        """
+        Gets the maximum depth of the system.
+        :return: The height of the system.
+        """
+        return self._max_depth(self.system, 0)
+
+    def _max_depth(self, gate, depth):
+        """
+        Calculates the max depth of the given gate recursively).
+        :param gate: The current gate.
+        :param depth: The current depth.
+        :return: the maximum depth from the given gate.
+        """
+        if isinstance(gate, BasicEvent):
+            return depth
+        return max(
+            self._max_depth(x, depth+1) for x in gate.get_input_gates()
+        )
 
 
 def flatten(l):

--- a/faulttree/faulttree.py
+++ b/faulttree/faulttree.py
@@ -75,13 +75,13 @@ class FaultTree:
         """
         return {x: False for x in self.basic_events.keys()}
 
-    def get_basic_event(self, name):
+    def get_basic_event(self, key):
         """
-        Returns the basic event with the given name or None if it does not
+        Returns the basic event with the given key or None if it does not
         exist.
         """
-        if name in self.basic_events:
-            return self.basic_events[name]
+        if key in self.basic_events:
+            return self.basic_events[key]
         return None
 
     def _construct_gates(self):

--- a/variableorderings/__init__.py
+++ b/variableorderings/__init__.py
@@ -1,0 +1,2 @@
+from variableorderings.manualordering import ManualOrdering
+from variableorderings.randomordering import RandomOrdering

--- a/variableorderings/__init__.py
+++ b/variableorderings/__init__.py
@@ -1,3 +1,4 @@
 from variableorderings.manualordering import ManualOrdering
 from variableorderings.randomordering import RandomOrdering
 from variableorderings.bfsordering import BFSOrdering
+from variableorderings.subtreecomplexity import SubTreeComplexity

--- a/variableorderings/__init__.py
+++ b/variableorderings/__init__.py
@@ -1,2 +1,3 @@
 from variableorderings.manualordering import ManualOrdering
 from variableorderings.randomordering import RandomOrdering
+from variableorderings.bfsordering import BFSOrdering

--- a/variableorderings/bfsordering.py
+++ b/variableorderings/bfsordering.py
@@ -1,0 +1,51 @@
+from variableorderings.baseordering import Ordering
+from faulttree.gates import BasicEvent
+
+
+class BFSOrdering(Ordering):
+    """
+    The BFS Ordering is an ordering based on breath first search.
+    The ordering is based on how deep a certain BasicEvent lies in the
+    system. It can either do top to bottom or bottom to top based on a
+    flag given in the initialiser.
+    """
+
+    def __init__(self, bottom_to_top=True):
+        """
+        Initialiser for a BFSOrdering.
+        :param bottom_to_top: Whether to order from bottom to top
+                              (the default) or top to bottom.
+        """
+        super().__init__('Topological ordering')
+        self.bottom_to_top = bottom_to_top
+        self.depths = {}
+
+    def order_variables(self, fault_tree):
+        """
+        Order the variables based on their depth.
+        :param fault_tree: The fault tree to order the BasicEvents of.
+        :return: The ordering of the variables.
+        """
+        self.parse_depth(fault_tree.get_system(), 0, fault_tree)
+        top_to_bot = sorted(self.depths.keys(),  # sort dictionary values
+                            key=lambda x: self.depths[x])
+        if self.bottom_to_top:
+            return reversed(top_to_bot)
+        else:
+            return top_to_bot
+
+    def parse_depth(self, gate, depth, fault_tree):
+        """
+        Calculates the depths of the basic events in a recursive way.
+        The depths are saved in a dictionary saved in the class (depths).
+        :param gate: The gate currently parsing.
+        :param depth: The current depth.
+        :param fault_tree: The fault tree to parse.
+        """
+        name = gate.get_name()
+        if isinstance(gate, BasicEvent):
+            if name not in self.depths or depth < self.depths[name]:
+                self.depths[fault_tree.get_basic_event_key(gate)] = depth
+        else:
+            for child in gate.get_input_gates():
+                self.parse_depth(child, depth+1, fault_tree)

--- a/variableorderings/subtreecomplexity.py
+++ b/variableorderings/subtreecomplexity.py
@@ -1,0 +1,72 @@
+from variableorderings.baseordering import Ordering
+from faulttree.gates import BasicEvent
+
+
+class SubTreeComplexity(Ordering):
+    """
+    The SubTreeComplexity ordering is an ordering based on how many gates
+    a certain BasicEvent influences. This is also weighted by how deep a
+    gate is in the tree: if it is deeper, it has a lower weight, so the
+    BasicEvent will get a lower score.
+    """
+
+    def __init__(self):
+        """
+        Initialiser for the SubTreeComplexity ordering.
+        """
+        super().__init__('Sub-Tree Complexity')
+        self.complexities = {}
+
+    def order_variables(self, fault_tree):
+        """
+        Orders the variable according to the SubTreeComplexity algorithm.
+        :param fault_tree: Fault tree to create the ordering for.
+        :return: The ordering for the variables.
+        """
+        self.score_events(fault_tree)
+        return sorted(  # inverse sort on the values of the dictionary
+            self.complexities.keys(), key=lambda x: -self.complexities[x]
+        )
+
+    def score_events(self, fault_tree):
+        """
+        Scores the basic events by their influence in the system.
+        :param fault_tree: The fault tree to score the BasicEvents of.
+        """
+        max_depth = fault_tree.max_depth()
+        for key, event in fault_tree.get_basic_events().items():
+            states = fault_tree.get_false_state()
+            states[key] = True
+            fault_tree.set_states(states)
+            self.complexities[key] = self.score_event(
+                fault_tree.get_system(),
+                max_depth
+            )
+
+    def score_event(self, gate, score):
+        """
+        Score an individual BasicEvent.
+        The score of a BasicEvent goes up by (max_depth - current_depth)
+        for a gate at depth current_depth if it enables a gate by being on
+        by itself.
+        :param gate: The current gate to look at.
+        :param score: The current score.
+        :return:
+        """
+        gate_score = SubTreeComplexity.get_gate_score(gate, score)
+        for child in gate.get_input_gates():
+            gate_score += self.score_event(child, score-1)
+        return gate_score
+
+    @staticmethod
+    def get_gate_score(gate, score):
+        """
+        Get the score of an individual gate.
+        :param gate: The gate to get the score of.
+        :param score: The score to give to the gate if it is succesfull.
+        :return: Score if the gate was succesfull, else 0.
+        """
+        if gate.apply(False) and not isinstance(gate, BasicEvent):
+            return score
+        else:
+            return 0


### PR DESCRIPTION
The minor changes are:
- Adding the orderings to the init file for their module for cleaner importing
- Fixing a documentation string that was incorrect

The BFSOrdering orders variables by the depth on which they lay in the system (can be reversed). The SubTreeComplexity Ordering orders variables based on how many gates they influence if they were activated.