### PR TITLE
More options to pretty print

### DIFF
--- a/prettyprinting/baseprinter.py
+++ b/prettyprinting/baseprinter.py
@@ -21,6 +21,7 @@ class _PrettyPrint:
         :param filename: The filename.
         :param dpi: The DPI of the drawing.
         """
+        plt.clf()
         self._pretty_print()
         plt.savefig(filename, dpi=dpi)
 
@@ -28,5 +29,6 @@ class _PrettyPrint:
         """
         Prints the current figure to a window.
         """
+        plt.clf()
         self._pretty_print()
         plt.show()

--- a/prettyprinting/baseprinter.py
+++ b/prettyprinting/baseprinter.py
@@ -15,20 +15,24 @@ class _PrettyPrint:
         """
         pass
 
-    def print_to_file(self, filename, dpi=None):
+    def print_to_file(self, filename, dpi=None, size=(10, 10)):
         """
         Prints the current figure to a file.
         :param filename: The filename.
         :param dpi: The DPI of the drawing.
+        :param size: Tuple with the size of the figure in inches.
         """
         plt.clf()
         self._pretty_print()
+        plt.gcf().set_size_inches(*size)
         plt.savefig(filename, dpi=dpi)
 
-    def print_to_window(self):
+    def print_to_window(self, size=(10, 10)):
         """
         Prints the current figure to a window.
+        :param size: Tuple with the size of the figure in inches.
         """
         plt.clf()
         self._pretty_print()
+        plt.gcf().set_size_inches(*size)
         plt.show()


### PR DESCRIPTION
1. Added a size parameter to printing graphs.
2. Added a clear figure before printing (before it was possible that graphs were printed wrongly because they were printing in the same file).